### PR TITLE
Model inference in separate process

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,16 +1,20 @@
 import base64
 import random
 import os
-import numpy as np
+import tempfile
+import json
+from multiprocessing import Pool
+
 from aiohttp import web
 from jsonrpcserver.aio import methods
 from jsonrpcserver.exceptions import InvalidParams
 from demo import load_model_from_args, start_image_demo
 
-'''
-In this function, we would call the fucntion with args set as values
-'''
+
 class Args:
+    """
+    With this class, we call the function to load the model
+    """
     def __init__(self):
         self.json = 'models/models/model-ff.json'
         self.weights = 'models/models/model-ff.h5'
@@ -20,15 +24,43 @@ class Args:
         self.gui = False
         self.path = ''
         self.image = ''
+
+
 class Model:
     def __init__(self):
         self.args = Args()
         self.model = load_model_from_args(self.args)
+
     def predict(self):
         return start_image_demo(self.args, self.model)
 
+
 app = web.Application()
-model = Model()
+
+
+def _classify(image):
+    import tensorflow as tf
+    from keras import backend as K
+    tf_config = tf.ConfigProto()
+    tf_config.gpu_options.allow_growth = True
+    sess = tf.Session(config=tf_config)
+    K.set_session(sess)
+
+    model = Model()
+
+    # Requires us to save the file to disk
+    f = tempfile.TemporaryFile(delete=False)
+    f.write(image)
+    # close vs. flush because flush apparently won't work on windows
+    f.close()
+    model.args.path = f.name
+    bounding_boxes, emotions = model.predict()
+    os.unlink(f.name) # cleanup temp file
+
+    del model
+    sess.close()
+    return bounding_boxes, emotions
+
 
 @methods.add
 async def classify(**kwargs):
@@ -38,31 +70,30 @@ async def classify(**kwargs):
         raise InvalidParams("image is required")
     if image_type is None:
         raise InvalidParams("image type is required")
+
     binary_image = base64.b64decode(image)
-    # this requires that we save the file. 
-    current_files = os.listdir('tmp')
-    tmp_file_name = 'tmp/tmp_' + str(random.randint(0,100000000000)) +'_.' + str(image_type)
-    while tmp_file_name in current_files:
-        tmp_file_name = 'tmp/tmp_' + str(random.randint(0,100000000000)) +'_.' + str(image_type)
-    with open(tmp_file_name,'wb') as f:
-        f.write(binary_image)
-    model.args.path = tmp_file_name
-    bounding_boxes, emotions = model.predict()
-    return {"bounding boxes": str(bounding_boxes),"predictions": str(emotions)}
+
+    with Pool(1) as p:
+        bounding_boxes, emotions = p.apply(_classify, (binary_image,))
+
+    return {
+        "bounding boxes": [
+            dict(x=d.left(), y=d.top(), w=d.right() - d.left(), h=d.bottom() - d.top()) for d in bounding_boxes
+        ],
+        "predictions": emotions
+    }
+
+
 async def handle(request):
     request = await request.text()
-    response = await methods.dispatch(request)
+    response = await methods.dispatch(request, trim_log_values=True)
 
     if response.is_notification:
         return web.Response()
     else:
         return web.json_response(response, status=response.http_status)
 
+
 if __name__ == '__main__':
     app.router.add_post('/', handle)
-    # create a tmp folder if it doesn't exist to hold files
-    try: 
-        os.mkdir('tmp')
-    except OSError:
-        print('tmp folder already exists, not created')
     web.run_app(app, host="127.0.0.1", port=8001)


### PR DESCRIPTION
Also:
- uses standard python `tempfile` functionality.
- formatting closer to PEP8
- tell tensorflow to not auto-allocate the entire gpu memory space.
- changes the response object to have structured objects instead of using `str()` on them (which would force the client the `json.loads` twice or do custom parsing of the rectangle objects.

before:
```
{"jsonrpc": "2.0", "result": {
    "bounding boxes": "[rectangle(572,112,676,215), rectangle(841,161,991,311), rectangle(365,42,469,146), rectangle(411,286,535,411), rectangle(742,93,867,217), rectangle(145,112,294,261)]",
    "predictions": "['fear', 'happy', 'sad', 'happy', 'anger', 'happy']"
}, "id": 1}
```

after:
```
{"jsonrpc": "2.0", "result": {
    "bounding boxes": [{"x": 572, "y": 112, "w": 104, "h": 103}, {"x": 841, "y": 161, "w": 150, "h": 150}, {"x": 365, "y": 42, "w": 104, "h": 104}, {"x": 411, "y": 286, "w": 124, "h": 125}, {"x": 742, "y": 93, "w": 125, "h": 124}, {"x": 145, "y": 112, "w": 149, "h": 149}],
    "predictions": ["fear", "happy", "sad", "happy", "anger", "happy"]
}, "id": 1}
```